### PR TITLE
Swap out remaining uses of word 'space' when it should be 'store'

### DIFF
--- a/docs/get-started/how-it-works.mdx
+++ b/docs/get-started/how-it-works.mdx
@@ -34,7 +34,7 @@ These things combined can be used to make rich collaborative applications, like 
 
 A share is like a shared folder.  Typically it's shared with a small group of trusted people.
 
-Each share has an address like `+bookclub.a18bu7axtn`. The first part helps you see which space you're interacting with, and the second, scrambly part makes it hard for others to guess.
+Each share has an address like `+bookclub.a18bu7axtn`. The first part helps you see which share you're interacting with, and the second, scrambly part makes it hard for others to guess.
 
 Anyone who knows the address can view and edit the data, so keep it out of public and share it only with people you trust.
 
@@ -80,7 +80,7 @@ When a public name is put into a document's path, prefixed with a tilde (e.g. `/
 
 But what about the ways we express our identity, like names, pronouns, or avatars?
 
-This kind of information is stored as documents within the commons, e.g. in your ["about me"](https://github.com/earthstar-project/earthstar/wiki/Standard-paths-and-data-formats-used-by-apps#about-author-profile-info) document. This has two big benefits: your identity can freely fluctuate between the spaces you use; and you can express your identity with as little or as much detail as you want!
+This kind of information is stored as documents within the commons, e.g. in your ["about me"](https://github.com/earthstar-project/earthstar/wiki/Standard-paths-and-data-formats-used-by-apps#about-author-profile-info) document. This has two big benefits: your identity can freely fluctuate between the shares you use; and you can express your identity with as little or as much detail as you want!
 
 ## Applications
 
@@ -94,7 +94,7 @@ Earthstar apps can typically run in browsers, or can be native apps.  They just 
 
 > Replica Servers: previously known as: *pub servers*, *cloud pockets*
 
-Most laptops and phones are not able to connect directly to each other, so we need some third space they can both connect to where data can be temporarily stashed for syncing.
+Most laptops and phones are not able to connect directly to each other, so we need some third share they can both connect to where data can be temporarily stashed for syncing.
 
 These are called **Replica Servers**.  You can run your own replica server(s) for your community on a small device like a raspberry pi, or hosted in the cloud.
 


### PR DESCRIPTION
The getting started how it works guide is great, but it seems to mix old an new terminology. Shares used to be called spaces, but a few places in this document still refer to them as spaces. I fixed that!