### PR TITLE
Update playground.mdx

### DIFF
--- a/docs/docs/playground.mdx
+++ b/docs/docs/playground.mdx
@@ -33,7 +33,7 @@ let shareAddress = "+pizza2nite.p34axr";
 With that settled, we need a storage driver to tell our replica how to save data. As we're just playing around in a console, let's persist everything to memory for now.
 
 ```js
-let driver = new Earthstar.ReplicaDriverMemory('+myshare.a123');
+let driver = new Earthstar.ReplicaDriverMemory(shareAddress);
 ```
 
 Now to instantiate our replica with the driver we just made:


### PR DESCRIPTION
When we declare the variable `shareAddress`, shouldn't we use it on line 36, when the _driver_ is created?