### PR TITLE
docs: update FOSDEM talk link

### DIFF
--- a/docs/get-started/like-a-bicycle.mdx
+++ b/docs/get-started/like-a-bicycle.mdx
@@ -6,10 +6,13 @@ meta:
 
 # Like a bicycle
 
-We're creating a decentralised, distributed technology a time when a lot of people are talking about 'web3' and it's worth talking about the ways  we are **not that**.
+We're creating a decentralised, distributed technology a time when a lot of people are talking about 'web3' and it's worth talking about the ways we are **not that**.
 
 In this talk from [FOSDEM 2022](https://fosdem.org/2022/), Sam Gwilym talks about how we want to build **tools which confer agency** against a backdrop of over-engineered solutions looking for a problem. It's ~20 minutes and gives a good idea of why Earthstar is the way it is, and how it works — kind of like a bicycle.
 
 <video controls>
-  <source src="http://bofh.nikhef.nl/events/FOSDEM/2022/D.web3/earthstar.webm" type="video/webm"/>
+  <source
+    src="https://ftp.osuosl.org/pub/fosdem/2022/D.web3/earthstar.webm"
+    type="video/webm"
+  />
 </video>


### PR DESCRIPTION
In the "Like a bicycle" page under _Getting Started_, the current URL to the FOSDEM talk ([https://bofh.nikhef.nl/events/FOSDEM/2022/D.web3/earthstar.webm](https://bofh.nikhef.nl/events/FOSDEM/2022/D.web3/earthstar.webm))is not resolving, and the video fails to load.

Updating the link to the URL used on the FOSDEM 2022 website: [https://ftp.osuosl.org/pub/fosdem/2022/D.web3/earthstar.webm](https://ftp.osuosl.org/pub/fosdem/2022/D.web3/earthstar.webm)