### PR TITLE
Fixed broken link

### DIFF
--- a/docs/get-started/how-it-works.mdx
+++ b/docs/get-started/how-it-works.mdx
@@ -96,7 +96,7 @@ In many p2p systems there's an emphasis on peers connecting directly to one anot
 
 For this reason we encourage the use of **Replica servers**, small redundant always-online peers reachable via URL. These servers are used to stash documents for syncing while peers are online.
 
-We are striving to make running a replica server as simple as possible. [Find out how to start your own](/getting-started/replica-server).
+We are striving to make running a replica server as simple as possible. [Find out how to start your own](/get-started/replica-server).
 
 Every share has its own separate network of Peers; data does not spread from one share to another. But a Peer can hold multiple share replicas at a time.
 


### PR DESCRIPTION
`/get-started/replica-server` instead of `/getting-started/replica-server`