### PR TITLE
Separate different available APIs

### DIFF
--- a/app/components/nav.tsx
+++ b/app/components/nav.tsx
@@ -18,8 +18,14 @@ const sitemap: Sitemap = {
     "User guide": "/docs/developer-guide",
     "Server guide": "/docs/server-guide",
     "Writing scripts": "/docs/scripting",
-    "API docs":
-      `https://doc.deno.land/https://deno.land/x/earthstar@${LATEST_EARTHSTAR_VERSION}/mod.ts`,
+    "Universal APIs":
+    `https://doc.deno.land/https://deno.land/x/earthstar@${LATEST_EARTHSTAR_VERSION}/src/entries/universal.ts`,
+    "Browser APIs":
+    `https://doc.deno.land/https://deno.land/x/earthstar@${LATEST_EARTHSTAR_VERSION}/src/entries/browser.ts`,
+    "Deno APIs":
+      `https://doc.deno.land/https://deno.land/x/earthstar@${LATEST_EARTHSTAR_VERSION}/src/entries/deno.ts`,
+      "Node APIs":
+      `https://doc.deno.land/https://deno.land/x/earthstar@${LATEST_EARTHSTAR_VERSION}/src/entries/node.ts`,
   },
 
   Specifications: {


### PR DESCRIPTION
Motivated by #310, where it was pointed out that the linked docs are missing certain APIs like `ReplicaDriverWeb`. This was because the linked docs were only linking to the Deno-specific entrypoint (which does not include `ReplicaDriverWeb`).

So instead of a single API docs link, I've separated them into four: universal, browser, Deno, and Node.