### PR TITLE
Use the directory that was created

### DIFF
--- a/docs/tutorials/run-a-server.mdx
+++ b/docs/tutorials/run-a-server.mdx
@@ -71,7 +71,7 @@ new Earthstar.Server([
 			console.log(`Creating replica for ${address}...`);
 
 			return new Earthstar.Replica({
-				driver: new Earthstar.ReplicaDriverFs(address, "./data"),
+				driver: new Earthstar.ReplicaDriverFs(address, "./.share_data"),
 			});
 		},
 	}),
@@ -111,7 +111,7 @@ new Earthstar.Server([
 			console.log(`Creating replica for ${address}...`);
 
 			return new Earthstar.Replica({
-				driver: new Earthstar.ReplicaDriverFs(address, "./data"),
+				driver: new Earthstar.ReplicaDriverFs(address, "./.share_data"),
 			});
 		},
 	}),


### PR DESCRIPTION
Great project, thank you for this!

One thing I noticed: https://earthstar-project.org/tutorials/run-a-server contains instructions to "Create a new directory and name it `.share_data` (starting with a dot)." But then the code uses `"./data"` for what seems to be storing share data, right? Was this by mistake? If so, here's a PR! :)