### PR TITLE
Don't forget to add your share to the Earthstar server config

### DIFF
--- a/docs/tutorials/create-a-chat-app.mdx
+++ b/docs/tutorials/create-a-chat-app.mdx
@@ -275,6 +275,7 @@ peer.sync("https://my.server", true);
 ```
 
 This won't work because there is no Earthstar server at `https://my.server`. [Fortunately we have a tutorial for running an Earthstar server](/tutorials/run-a-server).
+Don't forget to add your share (e.g. `"+chatting.bffblffbnzrjeqmh3s3vnuvztfibnzuex3e5h4nthsq7dum4mnlra"`) to the Earthstar server's `known_shares.json` configuration.
 
 <details>
  <summary>Make sure your browser allows Earthstar to save data</summary>


### PR DESCRIPTION
Don't forget to add your share (e.g. `"+chatting.bffblffbnzrjeqmh3s3vnuvztfibnzuex3e5h4nthsq7dum4mnlra"`) to the Earthstar server's `known_shares.json` configuration.